### PR TITLE
Better support for glob pattern matching, and support for multiline Jinja comment

### DIFF
--- a/src/core/tokenizer.ts
+++ b/src/core/tokenizer.ts
@@ -202,7 +202,7 @@ export default class Tokenizer {
       8: {
         input,
         type: tokenTypes.BLOCK_COMMENT,
-        regex: /^(\/\*[^]*?(?:\*\/|$))/,
+        regex: /^(\/\*[^]*?(?:\*\/|$))|^({#[^]*#}$)/,
       },
       9: {
         input,

--- a/src/dbt-command.ts
+++ b/src/dbt-command.ts
@@ -7,8 +7,8 @@ import { writer } from 'repl';
 
 program
   .option('-f, --file <file>', 'sql file to format')
-  .option('-d, --directory <directory>', 'The directory to recursively search.')
-  .option('-i, --ignore <pattern>', 'Glob friendly pattern(s) of files to ignore in directory', (pattern, previous) => previous.concat([pattern]), [])
+  .option('-d, --directory <directory>', 'The glob pattern to search for files.')
+  .option('-i, --ignore <pattern>', 'Glob friendly pattern(s) of files to ignore in directory. Can use multiple.', (pattern, previous) => previous.concat([pattern]), [])
   .option('-s', '--spaces <spaces>', 'number of spaces for indent. Defaults to 4.')
   .option('--upper', 'upercase reserved sql words')
   .option('--replace', 'overwrites the linted file(s).')
@@ -31,12 +31,12 @@ const do_work = (file: string) => {
   writer.write(formatted)
   
 }
-
+console.log(`Program Directory: ${program.directory}`)
 if(program.file){
   do_work(program.file);
 }else if (program.directory){
-  let match = `${program.directory}/**/*.sql`
-  let all_files = program.ignore == undefined? glob.sync(match): glob.sync(match, {ignore: program.ignore});
+  let search_pattern = program.directory;
+  let all_files = program.ignore == undefined? glob.sync(search_pattern): glob.sync(search_pattern, {ignore: program.ignore});
   all_files.forEach(do_work)
 }
 

--- a/src/dbt-command.ts
+++ b/src/dbt-command.ts
@@ -8,7 +8,8 @@ import { writer } from 'repl';
 program
   .option('-f, --file <file>', 'sql file to format')
   .option('-d, --directory <directory>', 'The directory to recursively search.')
-  .option('-i', '--indent <spaces>', 'number of spaces for indent. Defaults to 4.')
+  .option('-i, --ignore <pattern>', 'Glob friendly pattern(s) of files to ignore in directory', (pattern, previous) => previous.concat([pattern]), [])
+  .option('-s', '--spaces <spaces>', 'number of spaces for indent. Defaults to 4.')
   .option('--upper', 'upercase reserved sql words')
   .option('--replace', 'overwrites the linted file(s).')
   .parse(process.argv);
@@ -34,7 +35,8 @@ const do_work = (file: string) => {
 if(program.file){
   do_work(program.file);
 }else if (program.directory){
-  let all_files = glob.sync(`${program.directory}/**/*.sql`)
+  let match = `${program.directory}/**/*.sql`
+  let all_files = program.ignore == undefined? glob.sync(match): glob.sync(match, {ignore: program.ignore});
   all_files.forEach(do_work)
 }
 


### PR DESCRIPTION
Allow sending in of glob patterns to exclude and include files. 

Like so:
`dbt-formatter-linux64 -d "${HOME}/myproject/transform/{models,tests,macros}/**/*.sql" -i "${HOME}/myproject/transform/macros/some_macro_we_do_not_want_linted.sql" 